### PR TITLE
enable rate for IOS otherwise value is ignored

### DIFF
--- a/ios/Plugin/AudioAsset.swift
+++ b/ios/Plugin/AudioAsset.swift
@@ -34,6 +34,7 @@ public class AudioAsset: NSObject, AVAudioPlayerDelegate {
                 let player: AVAudioPlayer! = try AVAudioPlayer(contentsOf: pathUrl)
 
                 if player != nil {
+                    player.enableRate = true
                     player.volume = volume
                     player.prepareToPlay()
                     self.channels.append(player)


### PR DESCRIPTION
Hi @riderx 

Tested the lib on IOS and the rate did not work, just added the enableRate boolean and now it works !

cf https://developer.apple.com/documentation/avfaudio/avaudioplayer/1387084-enablerate

Regards,
Antony