### PR TITLE
fix IOS crashing if preload not loaded or channels does not have index

### DIFF
--- a/ios/Plugin/AudioAsset.swift
+++ b/ios/Plugin/AudioAsset.swift
@@ -67,12 +67,16 @@ public class AudioAsset: NSObject, AVAudioPlayerDelegate {
     }
 
     func play(time: TimeInterval) {
-        let player: AVAudioPlayer = channels[playIndex]
-        player.currentTime = time
-        player.numberOfLoops = 0
-        player.play()
-        playIndex += 1
-        playIndex = playIndex % channels.count
+        let player: AVAudioPlayer
+
+        if channels.count > 0 {
+            player = channels[playIndex]
+            player.currentTime = time
+            player.numberOfLoops = 0
+            player.play()
+            playIndex += 1
+            playIndex = playIndex % channels.count
+        }
     }
 
     func playWithFade(time: TimeInterval) {


### PR DESCRIPTION
Hi Martin,

I noticed that the Lib is crashing over IOS if preload did not work before, whereas in Android preload can fail but then you can call play, it does not trigger anything but on Android it is not crashing the app embedding the native audio lib.

I added over the channels size before accessing it at a given index and now it does not crash the app any more.

Regards,
Antony