### PR TITLE
Add missing `resolve` in `configure`

### DIFF
--- a/android/src/main/java/ee/forgr/audio/NativeAudio.java
+++ b/android/src/main/java/ee/forgr/audio/NativeAudio.java
@@ -135,6 +135,7 @@ public class NativeAudio
         this.audioManager.abandonAudioFocus(this);
       }
     }
+    call.resolve();
   }
 
   @PluginMethod

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -46,6 +46,7 @@ public class NativeAudio: CAPPlugin {
                 print("Failed to set setCategory audio")
             }
         }
+        call.resolve()
     }
 
     @objc func preload(_ call: CAPPluginCall) {


### PR DESCRIPTION
I added in both iOS and Android.
I haven't tested iOS though.
If the method is not async maybe it's better to change the typescript signature, isn't?
IDK, your call...

Fixes #48

I'm not sure when this started to become a problem honestly, as the same code used to work before in my app...