### PR TITLE
Fix asset already exists issue

### DIFF
--- a/android/src/main/java/ee/forgr/audio/NativeAudio.java
+++ b/android/src/main/java/ee/forgr/audio/NativeAudio.java
@@ -59,6 +59,8 @@ public class NativeAudio
 
     this.audioManager = (AudioManager) this.getActivity()
       .getSystemService(Context.AUDIO_SERVICE);
+
+    audioAssetList = new HashMap<>();
   }
 
   @Override


### PR DESCRIPTION
Fixes #54

- #54 

I'm not sure if it causes other issues though.
I believe the `load` method is called once the app is starts and the plugin is being loaded so I think this is the right place to put it.
Using this change I was not able to reproduce the issue on my device.

Let me know if you need anything else from my side.

As a side note, if the load is called before other methods, I think some cleaning of `initSoundPool` can be made, again, not sure.

I'm currently using this version with patch-package to allow testing my change.