### PR TITLE
feat(setCurrentTime): Added a setCurrentTime function (not tested)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Load an audio file
 ### isPreloaded(...)
 
 ```typescript
-isPreloaded(options: PreloadOptions) => Promise<boolean>
+isPreloaded(options: PreloadOptions) => Promise<{ found: boolean; }>
 ```
 
 Check if an audio file is preloaded
@@ -261,7 +261,7 @@ Check if an audio file is preloaded
 | ------------- | --------------------------------------------------------- |
 | **`options`** | <code><a href="#preloadoptions">PreloadOptions</a></code> |
 
-**Returns:** <code>Promise&lt;boolean&gt;</code>
+**Returns:** <code>Promise&lt;{ found: boolean; }&gt;</code>
 
 **Since:** 6.1.0
 
@@ -404,13 +404,30 @@ Set the rate of an audio file
 --------------------
 
 
+### setCurrentTime(...)
+
+```typescript
+setCurrentTime(options: { assetId: string; time: number; }) => Promise<void>
+```
+
+Set the current time of an audio file
+
+| Param         | Type                                            |
+| ------------- | ----------------------------------------------- |
+| **`options`** | <code>{ assetId: string; time: number; }</code> |
+
+**Since:** 6.5.0
+
+--------------------
+
+
 ### getCurrentTime(...)
 
 ```typescript
 getCurrentTime(options: { assetId: string; }) => Promise<{ currentTime: number; }>
 ```
 
-Set the current time of an audio file
+Get the current time of an audio file
 
 | Param         | Type                              |
 | ------------- | --------------------------------- |

--- a/android/src/main/java/ee/forgr/audio/AudioAsset.java
+++ b/android/src/main/java/ee/forgr/audio/AudioAsset.java
@@ -66,6 +66,16 @@ public class AudioAsset {
     return 0;
   }
 
+  public void setCurrentPosition(double time) {
+    if (audioList.size() != 1) return;
+
+    AudioDispatcher audio = audioList.get(playIndex);
+
+    if (audio != null) {
+        audio.setCurrentPosition(time);
+    }
+  }
+
   public double getCurrentPosition() {
     if (audioList.size() != 1) return 0;
 

--- a/android/src/main/java/ee/forgr/audio/AudioDispatcher.java
+++ b/android/src/main/java/ee/forgr/audio/AudioDispatcher.java
@@ -56,6 +56,12 @@ public class AudioDispatcher
     return mediaPlayer.getDuration() / 1000.0;
   }
 
+  public void setCurrentPosition(double time) {
+    if (mediaState == PLAYING || mediaState == PAUSE) {
+        mediaPlayer.seekTo((int) (time * 1000));
+    }
+  }
+
   public double getCurrentPosition() {
     return mediaPlayer.getCurrentPosition() / 1000.0;
   }

--- a/ios/Plugin/AudioAsset.swift
+++ b/ios/Plugin/AudioAsset.swift
@@ -59,6 +59,16 @@ public class AudioAsset: NSObject, AVAudioPlayerDelegate {
         return player.currentTime
     }
 
+    func setCurrentTime(time: TimeInterval) {
+        if channels.count != 1 {
+            return
+        }
+
+        let player: AVAudioPlayer = channels[playIndex]
+        
+        player.currentTime = time
+    }
+
     func getDuration() -> TimeInterval {
         if channels.count != 1 {
             return 0

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -15,6 +15,7 @@ CAP_PLUGIN(NativeAudio, "NativeAudio",
              CAP_PLUGIN_METHOD(resume, CAPPluginReturnPromise);
              CAP_PLUGIN_METHOD(unload, CAPPluginReturnPromise);
              CAP_PLUGIN_METHOD(setVolume, CAPPluginReturnPromise);
+             CAP_PLUGIN_METHOD(setCurrentTime, CAPPluginReturnPromise);
              CAP_PLUGIN_METHOD(getCurrentTime, CAPPluginReturnPromise);
              CAP_PLUGIN_METHOD(getDuration, CAPPluginReturnPromise);
              CAP_PLUGIN_METHOD(isPlaying, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -188,6 +188,16 @@ public class NativeAudio: CAPPlugin, AVAudioPlayerDelegate {
         return asset as? AudioAsset
     }
 
+    @objc func setCurrentTime(_ call: CAPPluginCall) {
+        guard let audioAsset: AudioAsset = self.getAudioAsset(call) else {
+            return
+        }
+
+        let time = call.getDouble("time") ?? 0
+        audioAsset.setCurrentTime(time: time)
+        call.resolve()
+    }
+
     @objc func getDuration(_ call: CAPPluginCall) {
         guard let audioAsset: AudioAsset = self.getAudioAsset(call) else {
             return

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -175,6 +175,13 @@ export interface NativeAudio {
   setRate(options: { assetId: string; rate: number }): Promise<void>;
   /**
    * Set the current time of an audio file
+   * @since 6.5.0
+   * @param option {@link AssetPlayOptions}
+   * @returns {Promise<void>}
+   */
+  setCurrentTime(options: { assetId: string, time: number }): Promise<void>;
+  /**
+   * Get the current time of an audio file
    * @since 5.0.0
    * @param option {@link AssetPlayOptions}
    * @returns {Promise<{ currentTime: number }>}

--- a/src/web.ts
+++ b/src/web.ts
@@ -25,6 +25,12 @@ export class NativeAudioWeb extends WebPlugin implements NativeAudio {
     return audio.pause();
   }
 
+  async setCurrentTime(options: { assetId: string; time: number; }): Promise<void> {
+    const audio: HTMLAudioElement = this.getAudioAsset(options.assetId).audio;
+    audio.currentTime = options.time;
+    return;
+  }
+
   async getCurrentTime(options: {
     assetId: string;
   }): Promise<{ currentTime: number }> {


### PR DESCRIPTION
Hello there, i added a function that allows to set the current time of an audio. This has NOT been tested anywhere since i encountered some problems while testing ("function not implemented on web").

The code is based on a pulll request from the capacitor-community plugin but corrected for this plugin. This "might" work :)

It would be nice if someone managed to test it on the web, IOS and Android 