### PR TITLE
Fix "complete" event not dispatched on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Load an audio file
 ### isPreloaded(...)
 
 ```typescript
-isPreloaded(options: PreloadOptions) => Promise<boolean>
+isPreloaded(options: PreloadOptions) => Promise<{ found: boolean; }>
 ```
 
 Check if an audio file is preloaded
@@ -261,7 +261,7 @@ Check if an audio file is preloaded
 | ------------- | --------------------------------------------------------- |
 | **`options`** | <code><a href="#preloadoptions">PreloadOptions</a></code> |
 
-**Returns:** <code>Promise&lt;boolean&gt;</code>
+**Returns:** <code>Promise&lt;{ found: boolean; }&gt;</code>
 
 **Since:** 6.1.0
 

--- a/android/src/main/java/ee/forgr/audio/AudioAsset.java
+++ b/android/src/main/java/ee/forgr/audio/AudioAsset.java
@@ -13,6 +13,7 @@ public class AudioAsset {
   private int playIndex = 0;
   private final String assetId;
   protected final NativeAudio owner;
+  protected AudioCompletionListener completionListener;
 
   AudioAsset(
     NativeAudio owner,
@@ -166,5 +167,15 @@ public class AudioAsset {
     if (audioList.size() != 1) return false;
 
     return audioList.get(playIndex).isPlaying();
+  }
+
+  public void setCompletionListener(AudioCompletionListener listener) {
+    this.completionListener = listener;
+  }
+
+  protected void notifyCompletion() {
+    if (completionListener != null) {
+      completionListener.onCompletion(this.assetId);
+    }
   }
 }

--- a/android/src/main/java/ee/forgr/audio/AudioCompletionListener.java
+++ b/android/src/main/java/ee/forgr/audio/AudioCompletionListener.java
@@ -1,0 +1,5 @@
+package ee.forgr.audio;
+
+public interface AudioCompletionListener {
+  void onCompletion(String assetId);
+}

--- a/android/src/main/java/ee/forgr/audio/AudioDispatcher.java
+++ b/android/src/main/java/ee/forgr/audio/AudioDispatcher.java
@@ -118,7 +118,7 @@ public class AudioDispatcher
         this.stop();
 
         if (this.owner != null) {
-          this.owner.dispatchComplete();
+          this.owner.notifyCompletion();
         }
       }
     } catch (Exception ex) {

--- a/android/src/main/java/ee/forgr/audio/NativeAudio.java
+++ b/android/src/main/java/ee/forgr/audio/NativeAudio.java
@@ -504,6 +504,7 @@ public class NativeAudio
               audioChannelNum,
               volume
             );
+            remoteAudioAsset.setCompletionListener(this::dispatchComplete);
             audioAssetList.put(audioId, remoteAudioAsset);
           } else if (
             uri.getScheme() != null && uri.getScheme().equals("file")
@@ -535,6 +536,7 @@ public class NativeAudio
               audioChannelNum,
               volume
             );
+            asset.setCompletionListener(this::dispatchComplete);
             audioAssetList.put(audioId, asset);
           } else {
             throw new IllegalArgumentException(

--- a/android/src/main/java/ee/forgr/audio/RemoteAudioAsset.java
+++ b/android/src/main/java/ee/forgr/audio/RemoteAudioAsset.java
@@ -45,6 +45,9 @@ public class RemoteAudioAsset extends AudioAsset {
         isPrepared = true;
         Log.d(TAG, "MediaPlayer prepared for " + uri.toString());
       });
+      mediaPlayer.setOnCompletionListener(mp -> {
+        notifyCompletion();
+      });
       mediaPlayer.setOnErrorListener((mp, what, extra) -> {
         Log.e(TAG, "MediaPlayer error: " + what + ", " + extra);
         return false;


### PR DESCRIPTION
fix: Ensure "complete" event is dispatched on Android after playing a remote audio asset

Fixes #134

Add a new interface `AudioCompletionListener` to handle audio completion events. This interface defines a single method `onCompletion(String assetId)`.

- Added `AudioCompletionListener` interface in `AudioCompletionListener.java`
- Modified `AudioDispatcher.java` to use `notifyCompletion()` instead of `dispatchComplete()`
- Modified `RemoteAudioAsset.java` to use `notifyCompletion()` instead of anonymous `OnCompletionListener`
- Modified `AudioAsset.java` to add `setCompletionListener()` and `notifyCompletion()` methods
- Modified `NativeAudio.java` to set the completion listener for `RemoteAudioAsset` and `AudioAsset`